### PR TITLE
Changed addTasks method

### DIFF
--- a/src/com/froobworld/avl/Avl.java
+++ b/src/com/froobworld/avl/Avl.java
@@ -4,12 +4,16 @@ import java.util.logging.Logger;
 
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitTask;
 
 import com.froobworld.avl.metrics.Metrics;
 import com.froobworld.avl.tasks.CompatibilityCheckTask;
 import com.froobworld.avl.tasks.MainTask;
 
 public class Avl extends JavaPlugin {
+
+	private BukkitTask task;
+
 	private AvlConfiguration config;
 
 	@Override
@@ -18,17 +22,22 @@ public class Avl extends JavaPlugin {
 			config = new AvlConfiguration(this, AvlConfiguration.CONFIG_CURRENT_VERSION, "config.yml");
 			config.loadFromFile();
 
-			addTasks();
+			startTasks();
 
 			new Metrics(this);
 			logger().info("Successfully enabled.");
 		}
 	}
 
-	private void addTasks() {
+	private void startTasks() {
+		if (this.task != null) {
+			this.task.cancel();
+		}
+
 		long ticksPerAllowSearch = config.getLong("ticks-per-allow-search",
 				600L /* Default value, if config does not contain the entry */);
-		Bukkit.getScheduler().runTaskTimer(this, new MainTask(this), 0L, ticksPerAllowSearch <= 0 ? 600 : ticksPerAllowSearch);
+		this.task = Bukkit.getScheduler().runTaskTimer(this, new MainTask(this), 0L,
+				ticksPerAllowSearch <= 0 ? 600 : ticksPerAllowSearch);
 	}
 
 	public AvlConfiguration getAvlConfig() {


### PR DESCRIPTION
I didn't get the flexibility of the recursive delayed task, to be dependent to the config value. I overworked the "addTasks" method. If you wish to restart the task (when implementing a reload command or something like that) just call the method again in the command execution. 