### PR TITLE
Add 1.16.2 compatibility

### DIFF
--- a/src/com/froobworld/avl/tasks/CompatibilityCheckTask.java
+++ b/src/com/froobworld/avl/tasks/CompatibilityCheckTask.java
@@ -10,7 +10,7 @@ public class CompatibilityCheckTask implements Runnable {
     private final static String VERSION = NAME.substring(NAME.lastIndexOf('.') + 1);
 
     private Avl avl;
-    private String[] supportedVersions = new String[]{"v1_14_R1", "v1_15_R1", "v1_16_R1"};
+    private String[] supportedVersions = new String[]{"v1_14_R1", "v1_15_R1", "v1_16_R1", "v1_16_R2"};
 
     private boolean pass;
 


### PR DESCRIPTION
Add 1.16.2 compatibility. 

It seems to work well on my network without any code change apart from adding 1.16.2 compatibility. 

Temporary build for users that need 1.16.2 compatibility waiting for the author to officially update it on spigot:
[https://assets.zencraft.net/VillagerOptimiser.jar](https://assets.zencraft.net/VillagerOptimiser.jar)